### PR TITLE
Alignment fix. Use specialized function. -Werror. Disable warning

### DIFF
--- a/jpg-store-bulk-purchase.cabal
+++ b/jpg-store-bulk-purchase.cabal
@@ -19,7 +19,7 @@ common lang
     -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
     -Wincomplete-record-updates -Wredundant-constraints -Widentities
     -rtsopts -fobject-code -fno-ignore-interface-pragmas
-    -fno-omit-interface-pragmas
+    -fno-omit-interface-pragmas -Wunrecognised-pragmas -Werror
 
   -- See Plutus Tx readme
   if flag(defer-plugin-errors)

--- a/src/Canonical/JpgStore/BulkPurchase.hs
+++ b/src/Canonical/JpgStore/BulkPurchase.hs
@@ -223,10 +223,10 @@ swapValidator _ r SwapScriptContext{aScriptContextTxInfo = SwapTxInfo{..}, aScri
     convertDatum :: forall a. DataConstraint(a) => Datum -> a
     convertDatum d =
       let a = getDatum d
-       in FROM_BUILT_IN_DATA("found datum that is not a swap", "2", a)
+      in FROM_BUILT_IN_DATA("found datum that is not a swap", "2", a)
 
     swaps :: [Swap]
-    swaps = fmap (\(_, d) -> convertDatum d) atxInfoData
+    swaps = map (\(_, d) -> convertDatum d) atxInfoData
 
     outputsAreValid :: Map PubKeyHash Value -> Bool
     outputsAreValid = validateOutputConstraints atxInfoOutputs


### PR DESCRIPTION
These are some small cleanup changes. The functionality has not been modified. 

- Fixes an alignment issue
- Adds -Werror and adds a flag to ignore the HLINT pragma warning
- Uses `map` instead of `fmap` because it is more informative and possibly more efficient.