### PR TITLE
Fix pragma warning flag. Monomorph the code for performance

### DIFF
--- a/jpg-store-bulk-purchase.cabal
+++ b/jpg-store-bulk-purchase.cabal
@@ -19,7 +19,7 @@ common lang
     -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
     -Wincomplete-record-updates -Wredundant-constraints -Widentities
     -rtsopts -fobject-code -fno-ignore-interface-pragmas
-    -fno-omit-interface-pragmas -Wunrecognised-pragmas -Werror
+    -fno-omit-interface-pragmas -Wno-unrecognised-pragmas -Werror
 
   -- See Plutus Tx readme
   if flag(defer-plugin-errors)

--- a/src/Canonical/DebugUtilities.h
+++ b/src/Canonical/DebugUtilities.h
@@ -1,12 +1,12 @@
 #if defined(DEBUG)
 #define TRACE_IF_FALSE(a,b,c) traceIfFalse a c
 #define TRACE_ERROR(a, b) traceError a
-#define FROM_BUILT_IN_DATA(m, c, a) case fromBuiltinData a :: Maybe a of { Nothing -> TRACE_ERROR(m, c); Just x -> x }
+#define FROM_BUILT_IN_DATA(m, c, a, t) case fromBuiltinData a :: Maybe t of { Nothing -> TRACE_ERROR(m, c); Just x -> x }
 #define DataConstraint(a) FromData a
 #else
 #define TRACE_IF_FALSE(a,b,c) traceIfFalse b c
 #define TRACE_ERROR(a, b) traceError b
-#define FROM_BUILT_IN_DATA(m, c, a) unsafeFromBuiltinData a :: a
+#define FROM_BUILT_IN_DATA(m, c, a, t) unsafeFromBuiltinData a :: t
 #define DataConstraint(a) UnsafeFromData a
 #endif
 

--- a/src/Canonical/JpgStore/BulkPurchase.hs
+++ b/src/Canonical/JpgStore/BulkPurchase.hs
@@ -220,10 +220,10 @@ swapValidator _ r SwapScriptContext{aScriptContextTxInfo = SwapTxInfo{..}, aScri
     thisValidator :: ValidatorHash
     thisValidator = ownHash' atxInfoInputs thisOutRef
 
-    convertDatum :: forall a. DataConstraint(a) => Datum -> a
+    convertDatum :: Datum -> Swap
     convertDatum d =
-      let a = getDatum d
-      in FROM_BUILT_IN_DATA("found datum that is not a swap", "2", a)
+      let theSwap = getDatum d
+      in FROM_BUILT_IN_DATA("found datum that is not a swap", "2", theSwap, Swap)
 
     swaps :: [Swap]
     swaps = map (\(_, d) -> convertDatum d) atxInfoData
@@ -231,7 +231,7 @@ swapValidator _ r SwapScriptContext{aScriptContextTxInfo = SwapTxInfo{..}, aScri
     outputsAreValid :: Map PubKeyHash Value -> Bool
     outputsAreValid = validateOutputConstraints atxInfoOutputs
 
-    foldSwaps :: (Swap -> a -> a) -> a -> a
+    foldSwaps :: (Swap -> Map PubKeyHash Value -> Map PubKeyHash Value) -> Map PubKeyHash Value -> Map PubKeyHash Value
     foldSwaps f init = foldr f init swaps
   -- This allows the script to validate all inputs and outputs on only one script input.
   -- Ignores other script inputs being validated each time
@@ -244,7 +244,7 @@ swapValidator _ r SwapScriptContext{aScriptContextTxInfo = SwapTxInfo{..}, aScri
           TRACE_IF_FALSE("signer is not the owner", "4", (all signerIsOwner swaps))
 
       Accept ->
-        -- Acts like a Buy, but we ignore any payouts that go to the signer of the
+        -- Acts like a buy, but we ignore any payouts that go to the signer of the
         -- transaction. This allows the seller to accept an offer from a buyer that
         -- does not pay the seller as much as they requested
         let

--- a/src/Canonical/Shared.hs
+++ b/src/Canonical/Shared.hs
@@ -41,7 +41,7 @@ wrap  :: forall a b c .
 wrap f a b c
   = check
     ( f
-        ( FROM_BUILT_IN_DATA("datum failed", "-1", a))
-        ( FROM_BUILT_IN_DATA("redeemer failed", "-2", b))
-        ( FROM_BUILT_IN_DATA("script context failed", "-3", c))
+        ( FROM_BUILT_IN_DATA("datum failed", "-1", a, a))
+        ( FROM_BUILT_IN_DATA("redeemer failed", "-2", b, b))
+        ( FROM_BUILT_IN_DATA("script context failed", "-3", c, c))
     )


### PR DESCRIPTION
This commit correctly disables the unrecognized pragma warning. It also simplifies the code by using a monomorphic version of functions that were overly polymorphic.