### PR TITLE
Generalize Payouts to Support Policy Id Counts

### DIFF
--- a/integration-tests/Main.hs
+++ b/integration-tests/Main.hs
@@ -175,8 +175,6 @@ runTests config@Config{..} = hspec $ aroundAllWith (createResources config) $ do
 
       let theAsset = show thePolicyId <> ".313233343536"
 
-
-
       eval evalConfig $ do
         void $ output (walletAddr royaltyWallet) "1000000 lovelace"
         void $ output (walletAddr marketplaceWallet) "1000000 lovelace"

--- a/jpg-store-bulk-purchase.cabal
+++ b/jpg-store-bulk-purchase.cabal
@@ -85,6 +85,7 @@ executable integration-tests
     , jpg-store-bulk-purchase
     , managed
     , mtl
+    , plutus-core
     , plutus-ledger
     , plutus-ledger-api
     , plutus-tx

--- a/src/Canonical/DebugUtilities.h
+++ b/src/Canonical/DebugUtilities.h
@@ -1,11 +1,13 @@
 #if defined(DEBUG)
 #define TRACE_IF_FALSE(a,b,c) traceIfFalse a c
 #define TRACE_ERROR(a, b) traceError a
+#define TRACE(a, b, c) trace a c
 #define FROM_BUILT_IN_DATA(m, c, a, t) case fromBuiltinData a :: Maybe t of { Nothing -> TRACE_ERROR(m, c); Just x -> x }
 #define DataConstraint(a) FromData a
 #else
 #define TRACE_IF_FALSE(a,b,c) traceIfFalse b c
 #define TRACE_ERROR(a, b) traceError b
+#define TRACE(a, b, c) trace b c
 #define FROM_BUILT_IN_DATA(m, c, a, t) unsafeFromBuiltinData a :: t
 #define DataConstraint(a) UnsafeFromData a
 #endif

--- a/src/Canonical/JpgStore/BulkPurchase.hs
+++ b/src/Canonical/JpgStore/BulkPurchase.hs
@@ -131,11 +131,11 @@ satisfyExpectation
 satisfyExpectation theValue (cs, (count, expectedTokenMap))
   = case M.lookup cs $ getValue theValue of
       Just actualTokenMap -> case validateTokenMap actualTokenMap expectedTokenMap of
-         Just leftOverMap
-            -> traceIfFalse "failed to validate policy count"
-             $ length (M.keys leftOverMap) >= count
-         Nothing -> trace "failed to validate token map" False
-      Nothing -> trace "failed to find policy" False
+         Just leftOverMap ->
+           let validPolicyCount = length (M.keys leftOverMap) >= count
+           in TRACE_IF_FALSE("failed to validate policy count", "10", validPolicyCount)
+         Nothing -> TRACE("failed to validate token map", "11", False)
+      Nothing -> TRACE("failed to find policy", "12", False)
 
 validateTokenMap :: M.Map TokenName Integer
                  -> M.Map TokenName Integer


### PR DESCRIPTION
This PR generalizes payouts, so the payout bundle can include specific tokens and a collection of token counts specified by policy id.

So, a user could make an offer on a specific policy id, by specifying the policy id with a count of 1. It could also request two from the same collection by requesting a count of two. In addition, the user could get paid out a specific token, by specifying the token name and count.